### PR TITLE
[-]: packages/main 테스트 인프라 복구

### DIFF
--- a/.github/workflows/main-package-coverage-comment.yml
+++ b/.github/workflows/main-package-coverage-comment.yml
@@ -1,0 +1,122 @@
+name: Main Package Coverage Comment
+
+on:
+  workflow_run:
+    workflows:
+      - Main Package Test
+    types:
+      - completed
+
+jobs:
+  comment:
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Download coverage artifact from triggering run
+        uses: actions/github-script@v7
+        env:
+          ARTIFACT_NAME: main-package-coverage
+          ARTIFACT_ZIP: ${{ runner.temp }}/main-package-coverage.zip
+        with:
+          script: |
+            const fs = require('fs');
+
+            const runId = context.payload.workflow_run.id;
+            const artifactName = process.env.ARTIFACT_NAME;
+            const { data } = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+
+            const artifact = data.artifacts.find((item) => item.name === artifactName);
+            if (!artifact) {
+              core.setFailed(`Artifact "${artifactName}" was not found for workflow run ${runId}.`);
+              return;
+            }
+
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: artifact.id,
+              archive_format: 'zip',
+            });
+
+            fs.writeFileSync(process.env.ARTIFACT_ZIP, Buffer.from(download.data));
+
+      - name: Extract coverage summary
+        run: |
+          mkdir -p "${RUNNER_TEMP}/main-package-coverage"
+          unzip -o "${RUNNER_TEMP}/main-package-coverage.zip" -d "${RUNNER_TEMP}/main-package-coverage"
+
+      - name: Comment coverage on pull request
+        uses: actions/github-script@v7
+        env:
+          COMMENT_MARKER: "<!-- main-package-coverage-comment -->"
+          COVERAGE_SUMMARY_PATH: ${{ runner.temp }}/main-package-coverage/coverage-summary.json
+        with:
+          script: |
+            const fs = require('fs');
+
+            const pr = context.payload.workflow_run.pull_requests[0];
+            if (!pr) {
+              core.info('No pull request is associated with this workflow run.');
+              return;
+            }
+
+            const summaryPath = process.env.COVERAGE_SUMMARY_PATH;
+            if (!fs.existsSync(summaryPath)) {
+              core.setFailed(`Coverage summary was not found at ${summaryPath}.`);
+              return;
+            }
+
+            const { total } = JSON.parse(fs.readFileSync(summaryPath, 'utf8'));
+            const formatMetric = (metric) => `${metric.pct.toFixed(2)}% (${metric.covered}/${metric.total})`;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.payload.workflow_run.id}`;
+            const body = [
+              process.env.COMMENT_MARKER,
+              '## packages/main coverage',
+              '',
+              '| Metric | Result |',
+              '| --- | --- |',
+              `| Lines | ${formatMetric(total.lines)} |`,
+              `| Statements | ${formatMetric(total.statements)} |`,
+              `| Functions | ${formatMetric(total.functions)} |`,
+              `| Branches | ${formatMetric(total.branches)} |`,
+              '',
+              `[Workflow run](${runUrl})`,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              per_page: 100,
+            });
+
+            const existingComment = comments.find((comment) =>
+              comment.user?.type === 'Bot' && comment.body?.includes(process.env.COMMENT_MARKER)
+            );
+
+            if (existingComment) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existingComment.id,
+                body,
+              });
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr.number,
+              body,
+            });

--- a/.github/workflows/main-package-test.yml
+++ b/.github/workflows/main-package-test.yml
@@ -1,0 +1,43 @@
+name: Main Package Test
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.12.4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run packages/main tests with coverage
+        run: pnpm -C packages/main test:coverage
+
+      - name: Upload packages/main coverage summary
+        if: success() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
+        with:
+          name: main-package-coverage
+          path: packages/main/coverage/coverage-summary.json
+          if-no-files-found: error
+          retention-days: 7

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "main": "pnpm -F @react-tutorial-overlay/main",
     "document": "pnpm -F @react-tutorial-overlay/document",
     "dev": "pnpm -r dev",
-    "size": "size-limit",
-    "build": "pnpm size-limit && pnpm main build",
+    "size": "pnpm main build && size-limit",
+    "build": "pnpm size",
     "docs": "pnpm document build"
   },
   "keywords": [

--- a/packages/main/jest.config.js
+++ b/packages/main/jest.config.js
@@ -1,6 +1,24 @@
-/** @type {import('ts-jest/dist/types').InitialOptionsTsJest} */
+/** @type {import('jest').Config} */
 module.exports = {
-  preset: 'ts-jest',
   testEnvironment: 'jsdom',
+  roots: ['<rootDir>/src', '<rootDir>/test'],
+  testMatch: ['**/*.test.ts', '**/*.test.tsx'],
   setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/'],
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        tsconfig: {
+          esModuleInterop: true,
+          jsx: 'react',
+          lib: ['dom', 'esnext'],
+          module: 'commonjs',
+          noEmit: true,
+          rootDir: '.',
+        },
+      },
+    ],
+  },
 };

--- a/packages/main/package.json
+++ b/packages/main/package.json
@@ -3,7 +3,8 @@
   "scripts": {
     "dev": "tsup --watch",
     "build": "tsup",
-    "test": "jest --runInBand"
+    "test": "jest --runInBand",
+    "test:coverage": "jest --runInBand --coverage --coverageReporters=text-summary --coverageReporters=json-summary"
   },
   "husky": {
     "hooks": {

--- a/packages/main/test/setup.ts
+++ b/packages/main/test/setup.ts
@@ -1,0 +1,17 @@
+import '@testing-library/jest-dom';
+import { cleanup, act } from '@testing-library/react';
+import { tutorial } from '../src/core/tutorial';
+
+Object.defineProperty(Element.prototype, 'scrollIntoView', {
+  configurable: true,
+  value: jest.fn(),
+  writable: true,
+});
+
+afterEach(() => {
+  cleanup();
+  act(() => {
+    tutorial.close();
+  });
+  jest.clearAllMocks();
+});

--- a/packages/main/test/tutorial-overlay.test.tsx
+++ b/packages/main/test/tutorial-overlay.test.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { TutorialOverlay } from '../src/components/tutorial-overlay';
+import { tutorial } from '../src/core/tutorial';
+
+describe('TutorialOverlay', () => {
+  test('stays mounted when a target element cannot be found', () => {
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<TutorialOverlay />);
+
+    act(() => {
+      tutorial.open({
+        steps: [
+          {
+            title: 'Missing target',
+            content: 'Overlay stays open',
+            targetIds: ['does-not-exist'],
+          },
+        ],
+        options: {},
+      });
+    });
+
+    expect(screen.getByText('Missing target')).toBeInTheDocument();
+    expect(screen.getByText('Overlay stays open')).toBeInTheDocument();
+    expect(screen.getByText('1 / 1')).toBeInTheDocument();
+    expect(errorSpy).toHaveBeenCalledWith('Highlighted element with id does-not-exist was not found.');
+  });
+});

--- a/packages/main/test/tutorial.test.tsx
+++ b/packages/main/test/tutorial.test.tsx
@@ -1,0 +1,94 @@
+import React from 'react';
+import { act, render, screen } from '@testing-library/react';
+import { useTutorialStore } from '../src/core/store';
+import { tutorial } from '../src/core/tutorial';
+import type { Tutorial } from '../src/core/types';
+
+const twoStepTutorial: Tutorial = {
+  steps: [
+    { title: 'Step 1', targetIds: ['first-target'] },
+    { title: 'Step 2', targetIds: ['second-target'] },
+  ],
+  options: {},
+};
+
+function StateProbe() {
+  const {
+    index,
+    open,
+    tutorial: { steps },
+  } = useTutorialStore();
+
+  return (
+    <div>
+      <span data-testid="open">{String(open)}</span>
+      <span data-testid="index">{String(index)}</span>
+      <span data-testid="title">{steps[index]?.title ?? 'none'}</span>
+    </div>
+  );
+}
+
+describe('tutorial core API', () => {
+  test('tutorial.open opens the tutorial and tutorial.next advances the current step', () => {
+    render(<StateProbe />);
+
+    expect(screen.getByTestId('open')).toHaveTextContent('false');
+    expect(screen.getByTestId('index')).toHaveTextContent('0');
+
+    act(() => {
+      tutorial.open(twoStepTutorial);
+    });
+
+    expect(screen.getByTestId('open')).toHaveTextContent('true');
+    expect(screen.getByTestId('index')).toHaveTextContent('0');
+    expect(screen.getByTestId('title')).toHaveTextContent('Step 1');
+
+    act(() => {
+      tutorial.next();
+    });
+
+    expect(screen.getByTestId('open')).toHaveTextContent('true');
+    expect(screen.getByTestId('index')).toHaveTextContent('1');
+    expect(screen.getByTestId('title')).toHaveTextContent('Step 2');
+  });
+
+  test('tutorial.next closes the tutorial on the last step', () => {
+    render(<StateProbe />);
+
+    act(() => {
+      tutorial.open({
+        steps: [{ title: 'Only step', targetIds: ['only-target'] }],
+        options: {},
+      });
+    });
+
+    expect(screen.getByTestId('open')).toHaveTextContent('true');
+    expect(screen.getByTestId('title')).toHaveTextContent('Only step');
+
+    act(() => {
+      tutorial.next();
+    });
+
+    expect(screen.getByTestId('open')).toHaveTextContent('false');
+    expect(screen.getByTestId('index')).toHaveTextContent('0');
+    expect(screen.getByTestId('title')).toHaveTextContent('none');
+  });
+
+  test('tutorial.close closes an open tutorial', () => {
+    render(<StateProbe />);
+
+    act(() => {
+      tutorial.open(twoStepTutorial);
+    });
+
+    expect(screen.getByTestId('open')).toHaveTextContent('true');
+
+    act(() => {
+      tutorial.close();
+    });
+
+    expect(screen.getByTestId('open')).toHaveTextContent('false');
+    expect(screen.getByTestId('index')).toHaveTextContent('0');
+    expect(screen.getByTestId('title')).toHaveTextContent('none');
+  });
+});


### PR DESCRIPTION
## 요약
- `packages/main` Jest 설정과 setup 파일을 복구해 테스트가 정상 실행되도록 정리했습니다.
- `tutorial.open()` / `next()` / `close()` 최소 동작과 target element 미존재 시 overlay resilience를 테스트로 추가했습니다.
- PR에서 `packages/main` 테스트와 coverage를 자동 실행하고, coverage 요약을 PR 코멘트로 갱신하는 GitHub Actions를 추가했습니다.
- 루트 `pnpm build`가 깨끗한 상태에서도 통과하도록 `size-limit` 실행 순서를 빌드 이후로 조정했습니다.

## 검증
- `pnpm -C packages/main test`
- `pnpm -C packages/main test:coverage`
- `pnpm -C packages/main build`
- `pnpm build`
- `pnpm size`

## 참고
- coverage comment 워크플로는 `workflow_run` 기반이라 기본 브랜치 반영 후 다음 PR부터 안정적으로 코멘트를 남깁니다.