### PR TITLE
[-]: changeset 파싱 핫픽스

### DIFF
--- a/.changeset/wise-cars-shout.md
+++ b/.changeset/wise-cars-shout.md
@@ -1,3 +1,4 @@
+---
 'react-tutorial-overlay': minor
 ---
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
+  - "."
   - "packages/*"


### PR DESCRIPTION
## 변경 사항
- `.changeset/wise-cars-shout.md` 맨 위에 누락된 frontmatter 구분선 `---`를 추가했습니다.
- `pnpm-workspace.yaml`에 루트 `.`를 포함시켜 Changesets가 `react-tutorial-overlay` 루트 패키지를 workspace 패키지로 인식하도록 수정했습니다.

## 원인
- PR #12에서 추가한 changeset 파일이 YAML frontmatter 형식을 만족하지 않았습니다.
- 동시에 Changesets가 루트 패키지를 workspace 범위로 보지 못해, 패키지 이름을 인식할 수 없는 상태였습니다.

## 검증
- `pnpm changeset status --verbose`

## 결과
- Changesets가 `react-tutorial-overlay 0.2.0` minor bump 예정 상태를 정상 인식합니다.
