### PR TITLE
[-]: changeset frontmatter 핫픽스

### DIFF
--- a/.changeset/neat-pears-wait.md
+++ b/.changeset/neat-pears-wait.md
@@ -1,3 +1,4 @@
+---
 'react-tutorial-overlay': minor
 ---
 


### PR DESCRIPTION
## 변경 사항
- `.changeset/neat-pears-wait.md`에 누락된 frontmatter 시작 구분선 `---`를 추가했습니다.

## 원인
- progress control API 작업용 changeset 파일이 Changesets YAML frontmatter 형식을 만족하지 않아 release workflow가 파싱 단계에서 실패하고 있었습니다.

## 검증
- `pnpm changeset status --verbose`

## 결과
- Changesets가 `react-tutorial-overlay 0.2.0` minor bump 예정 상태를 정상 인식합니다.
