### PR TITLE
[-]: trusted publishing 전환

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
       pull-requests: write
 
     steps:
@@ -24,10 +25,10 @@ jobs:
         with:
           version: 10.12.4
 
-      - name: Use Node.js 20
+      - name: Use Node.js 22
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
@@ -43,4 +44,3 @@ jobs:
           commit: "[-]: version packages"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -4,7 +4,15 @@ This repository now uses [Changesets](https://github.com/changesets/changesets) 
 
 ## One-time setup
 
-The GitHub release workflow expects an `NPM_TOKEN` repository secret with publish access to the `react-tutorial-overlay` npm package.
+This repository uses npm Trusted Publishing for GitHub Actions.
+
+Set up once on npm:
+
+1. Open the `react-tutorial-overlay` package settings on npm.
+2. Add a Trusted Publisher for the `sjsjsj1246/react-tutorial-overlay` GitHub repository.
+3. Set the workflow filename to `release.yml`.
+
+After that, the GitHub release workflow can publish without storing a long-lived `NPM_TOKEN` secret.
 
 ## Everyday workflow
 
@@ -65,6 +73,7 @@ On pushes to `main` or manual dispatch, `.github/workflows/release.yml` runs `ch
 - If unreleased changesets exist, it opens or updates a release PR.
 - If the release PR has already been merged and version files are on `main`, it runs `pnpm release`.
 - `pnpm release` verifies tests, docs lint/build, size limits, and then runs `changeset publish`.
+- Publishing uses GitHub Actions OIDC via npm Trusted Publishing instead of an `NPM_TOKEN` secret.
 
 ## Notes for this repo
 


### PR DESCRIPTION
## 변경 사항
- release workflow를 npm Trusted Publishing(OIDC) 방식으로 전환했습니다.
- `.github/workflows/release.yml`에 `id-token: write` 권한을 추가했습니다.
- npm Trusted Publishing 요구사항에 맞춰 release workflow의 Node 버전을 22로 올렸습니다.
- `NPM_TOKEN` secret 의존성을 제거했습니다.
- `docs/releasing.md`를 Trusted Publishing 기준으로 업데이트했습니다.

## 검증
- workflow / 문서 변경만 포함
- release workflow는 Trusted Publisher 설정이 완료된 상태에서 다음 실행부터 OIDC publish를 사용합니다.

## 메모
- 이 PR 머지 후에는 repository `NPM_TOKEN` secret 없이도 release workflow가 publish할 수 있어야 합니다.
