### PR TITLE
[-]: release와 publish 워크플로 분리

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,16 +1,14 @@
-name: Release
+name: Publish
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 jobs:
-  release_pr:
+  publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
+      id-token: write
 
     steps:
       - name: Checkout repository
@@ -33,11 +31,5 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Create or update release PR
-        uses: changesets/action@v1
-        with:
-          version: pnpm version-packages
-          title: "[-]: version packages"
-          commit: "[-]: version packages"
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish current main release
+        run: pnpm release

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -20,7 +20,8 @@ After that, the GitHub release workflow can publish without storing a long-lived
 2. Add a changeset before opening or updating the PR.
 3. Merge the PR into `main`.
 4. Let the Release workflow open or update the version PR.
-5. Merge the version PR to publish the new npm version and update `CHANGELOG.md`.
+5. Merge the version PR to update `CHANGELOG.md` and package versions on `main`.
+6. Run the `Publish` workflow manually when you want to ship that version to npm.
 
 ## Adding a changeset
 
@@ -68,10 +69,15 @@ The normal path should be the GitHub Release workflow instead of local publishin
 
 ## What the release workflow does
 
-On pushes to `main` or manual dispatch, `.github/workflows/release.yml` runs `changesets/action`.
+On pushes to `main`, `.github/workflows/release.yml` runs `changesets/action`.
 
 - If unreleased changesets exist, it opens or updates a release PR.
-- If the release PR has already been merged and version files are on `main`, it runs `pnpm release`.
+- It does not publish to npm.
+
+## What the publish workflow does
+
+Run `.github/workflows/publish.yml` manually when you want to ship the current version on `main`.
+
 - `pnpm release` verifies tests, docs lint/build, size limits, and then runs `changeset publish`.
 - Publishing uses GitHub Actions OIDC via npm Trusted Publishing instead of an `NPM_TOKEN` secret.
 


### PR DESCRIPTION
## 변경 사항
- `release.yml`을 release PR 생성/업데이트 전용 workflow로 축소했습니다.
- 실제 npm 배포는 수동 실행 전용 `publish.yml` workflow로 분리했습니다.
- 이제 일반 기능 PR이 `main`에 머지되어도 자동 publish가 시도되지 않습니다.
- `docs/releasing.md`를 새 운영 방식에 맞춰 업데이트했습니다.

## 새 동작 방식
- `main` 머지: release PR 생성 또는 갱신만 수행
- version PR 머지: 버전과 changelog만 `main`에 반영
- 실제 배포: GitHub Actions에서 `Publish` workflow를 수동 실행

## 이유
- 기존 구조는 `main`에 version commit이 남아 있는 상태에서 다른 PR을 머지해도 publish가 다시 시도될 수 있었습니다.
- release PR과 publish를 분리해서 배포 시점을 명시적으로 제어하도록 바꿨습니다.
