### PR TITLE
[-]: publish 런타임 버전 고정

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,15 +21,21 @@ jobs:
         with:
           version: 10.12.4
 
-      - name: Use Node.js 22
+      - name: Use Node.js 22.14
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 22.14.0
           cache: pnpm
           registry-url: https://registry.npmjs.org
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Upgrade npm for trusted publishing
+        run: npm install -g npm@latest
+
+      - name: Print runtime versions
+        run: node -v && npm -v
 
       - name: Publish current main release
         run: pnpm release


### PR DESCRIPTION
## 변경 사항
- `publish.yml`의 Node 버전을 Trusted Publishing 요구사항에 맞춰 `22.14.0`으로 고정했습니다.
- publish 전에 `npm@latest`로 업그레이드하도록 추가했습니다.
- publish 실행 전에 `node -v`, `npm -v`를 출력하도록 해서 다음 실패 시 런타임 버전을 바로 확인할 수 있게 했습니다.

## 이유
- npm Trusted Publishing은 공식적으로 더 높은 Node/npm 런타임을 요구합니다.
- 기존 `node-version: 22`만으로는 Trusted Publishing 요구 버전을 만족하지 못했을 가능성이 있습니다.

## 다음 확인 포인트
- 이 PR 머지 후 `Publish` workflow를 다시 수동 실행
- 로그에서 `node -v`, `npm -v` 값 확인
- 이후에도 404면 npm Trusted Publisher 설정값 mismatch를 다시 봐야 합니다.
