### PR TITLE
[-]: publish 후 github release 생성

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     steps:
@@ -39,3 +39,27 @@ jobs:
 
       - name: Publish current main release
         run: pnpm release
+
+      - name: Read package version
+        id: package_version
+        run: echo "version=$(node -p \"require('./package.json').version\")" >> "$GITHUB_OUTPUT"
+
+      - name: Create Git tag if missing
+        run: |
+          TAG="v${{ steps.package_version.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "Tag $TAG already exists"
+            exit 0
+          fi
+          git tag "$TAG"
+          git push origin "$TAG"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="v${{ steps.package_version.outputs.version }}"
+          gh release create "$TAG" \
+            --title "$TAG" \
+            --generate-notes \
+            --verify-tag

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -80,6 +80,7 @@ Run `.github/workflows/publish.yml` manually when you want to ship the current v
 
 - `pnpm release` verifies tests, docs lint/build, size limits, and then runs `changeset publish`.
 - Publishing uses GitHub Actions OIDC via npm Trusted Publishing instead of an `NPM_TOKEN` secret.
+- After npm publish succeeds, the workflow creates a `v<version>` Git tag and a GitHub Release with generated release notes.
 
 ## Notes for this repo
 


### PR DESCRIPTION
## 변경 사항
- `Publish` workflow가 npm publish 성공 후 현재 패키지 버전으로 Git tag를 생성하도록 추가했습니다.
- 같은 workflow에서 GitHub Release도 자동 생성하도록 추가했습니다.
- release notes는 GitHub generated notes를 사용합니다.
- `docs/releasing.md`에 publish 후 tag / GitHub Release 생성 흐름을 문서화했습니다.

## 새 동작 방식
- `Publish` workflow 수동 실행
- `pnpm release` 성공
- `v<version>` 태그 생성 및 푸시
- GitHub Release 자동 생성

## 메모
- 태그가 이미 존재하면 재생성하지 않습니다.
- GitHub Release 생성에는 workflow의 `contents: write` 권한이 필요합니다.
